### PR TITLE
add: github学習ページに学習履歴ページを新設

### DIFF
--- a/app/github/LearningHistory/page.tsx
+++ b/app/github/LearningHistory/page.tsx
@@ -1,0 +1,9 @@
+const LearningHistoryPage = () => {
+  return (
+    <div>
+      <h1 className="mt-12 text-center text-2xl">あなたの学習履歴</h1>
+    </div>
+  );
+};
+
+export default LearningHistoryPage

--- a/app/github/components/Header.tsx
+++ b/app/github/components/Header.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+
+const GithubHeader = () => {
+  return (
+    <div className="w-full bg-gray-100">
+      <div className="flex max-w-2xl justify-between mx-auto py-4 items-center">
+        <h2 className="text-lg font-bold">
+          <Link href={"/github"}>Learn The Github</Link>
+        </h2>
+        <nav>
+          <ul className="flex gap-8 text-sm">
+            <li className="text-blue-700 hover:text-blue-900">
+              <Link href="/github/LearningHistory">学習履歴を確認する</Link>
+            </li>
+            <li className="text-blue-700 hover:text-blue-900">
+              <Link href="/dashboard">ホームへ戻る</Link>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  );
+};
+
+export default GithubHeader;

--- a/app/github/layout.tsx
+++ b/app/github/layout.tsx
@@ -1,0 +1,19 @@
+import { Metadata } from "next";
+import { ReactNode } from "react";
+import GithubHeader from "./components/Header";
+
+export const metadata: Metadata = {
+  title: "github learnページ",
+  description: "github用の学習ページです。githubとは何か、githubでできること、細かい使い方までステップに分けて学習することができます。また、学習した履歴を残すことができどこまで習得したかを確認できるようになっています。"
+}
+
+const GithubLayoutPage = ({ children }: { children: ReactNode }) => {
+  return (
+    <div>
+      <GithubHeader />
+      { children }
+    </div>
+  );
+};
+
+export default GithubLayoutPage;

--- a/app/github/lib/steps.ts
+++ b/app/github/lib/steps.ts
@@ -1,5 +1,5 @@
 export const githubLearnSteps = [
-  { title: "ステップ１", content: "featureブランチを作成" },
-  { title: "ステップ２", content: "Pull Requestを作成してmergeを実行する" },
-  { title: "ステップ３", content: "Issueを作成してpull requestに繋げる" },
+  { title: "ステップ１", content: "Issueを作成してpull requestに繋げる" },
+  { title: "ステップ２", content: "featureブランチを作成" },
+  { title: "ステップ３", content: "Pull Requestを作成してmergeを実行する" },
 ];

--- a/app/github/lib/steps.ts
+++ b/app/github/lib/steps.ts
@@ -1,0 +1,5 @@
+export const githubLearnSteps = [
+  { title: "ステップ１", content: "featureブランチを作成" },
+  { title: "ステップ２", content: "Pull Requestを作成してmergeを実行する" },
+  { title: "ステップ３", content: "Issueを作成してpull requestに繋げる" },
+];

--- a/app/github/page.tsx
+++ b/app/github/page.tsx
@@ -1,16 +1,18 @@
+import { githubLearnSteps } from "./lib/steps";
+
 const GitHubPage = () => {
   return (
     <div>
-      <h1 className="text-center text-3xl mt-20">GitHub学習ページ</h1>
+      <h1 className="text-center text-3xl mt-12">GitHub学習ページ</h1>
       <ul className="max-w-xl mx-auto mt-12">
-        <li>
-          <h3 className="text-xl">ステップ１</h3>
-          <p>featureブランチを作成</p>
-        </li>
-        <li className="mt-6">
-          <h3 className="text-xl">ステップ２</h3>
-          <p>Pull Requestを作成してmergeを実行する</p>
-        </li>
+        {githubLearnSteps.map((index) => {
+          return (
+            <li key={index.title} className="mb-6">
+              <h3 className="text-xl">{index.title}</h3>
+              <p>{index.content}</p>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );


### PR DESCRIPTION
## このPRは以下のIssueに対応しています
Closes #4

##　概要
Githubの学習用ページに新しいステップと、ユーザーの学習した履歴が確認できるページを新設しました。

## 変更点
- `/learningHistory`　ページを新設
- ステップ用のlibファイルを作成、さらにステップ3のIssuesの使い方を追加

## 確認事項
- [x] プレビューURLで文言が正しく表示されているか 
- [x] ステップの順として間違いがないか

## 備考
レビュー後、問題がなければマージして本番デプロイをテストしてください。